### PR TITLE
bugfix: Updated protobuf gradle again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
+        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.9'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 14 09:48:06 CST 2019
+#Sat Mar 28 15:45:45 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
New Android Studio 3.6.1 doesn't work with 0.8.9 or lower?
More about it here -
https://github.com/google/protobuf-gradle-plugin/issues/311#issuecomment-504589705