### PR TITLE
Hotfix: Failure to manually provision due to calling startActivity outside an activity

### DIFF
--- a/app/src/main/java/com/espressif/ui/activities/AddDeviceActivity.java
+++ b/app/src/main/java/com/espressif/ui/activities/AddDeviceActivity.java
@@ -545,6 +545,7 @@ public class AddDeviceActivity extends AppCompatActivity {
         finish();
         Intent wifiProvisioningIntent = new Intent(getApplicationContext(), ProvisionLanding.class);
         wifiProvisioningIntent.putExtra(AppConstants.KEY_SECURITY_TYPE, securityType);
+        wifiProvisioningIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
         if (espDevice != null) {
             wifiProvisioningIntent.putExtra(AppConstants.KEY_DEVICE_NAME, espDevice.getDeviceName());


### PR DESCRIPTION
On newer Android devices, attempting to manually provision causes an application crash 

This allows the intent to be started

Tried on Android 9, 10