### PR TITLE
update Android minSdkVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository contains the source code for the companion Android app for this 
   
 ## Requirements  
   
-- Supports Android 7.0 (API level 24) and above.  
+- Supports Android 5.0 (API level 21) and above.  
 
 ##  How to include  
   

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId "com.espressif.wifi_provisioning"
-        minSdkVersion 23
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 9
         versionName "2.0.6 - ${getGitHash()}"

--- a/provisioning/build.gradle
+++ b/provisioning/build.gradle
@@ -23,7 +23,7 @@ android {
     buildToolsVersion "29.0.1"
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Hello,

We are working on a react-native app that is using this library. Currently we use the same device-support as the popular package Expo(https://expo.io/). We want to support a minSdkVersion of 21. We tested this library with this version and everything seems to be working fine.

Is there a specific reason why the minSdkVersion is 23? We tested it and we didn’t find issues so it will be an improvement for this library is this can be merged.

This fixes #30 