### PR TITLE
set correct minSdkVersion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository contains the source code for the companion Android app for this 
   
 ## Requirements  
   
-- Supports Android 7.0 (API level 24) and above.  
+- Supports Android 6.0 (API level 23) and above.  
 
 ##  How to include  
   


### PR DESCRIPTION
The readme specified a different minSdkVersion as the code. 
This is the correct version.

See https://github.com/espressif/esp-idf-provisioning-android/pull/31#issuecomment-738606716 for more info.
