### PR TITLE
BugFix: ESPDevice - Fixed BLE characteristic read & write issue

### DIFF
--- a/provisioning/src/main/java/com/espressif/provisioning/ESPDevice.java
+++ b/provisioning/src/main/java/com/espressif/provisioning/ESPDevice.java
@@ -757,7 +757,7 @@ public class ESPDevice {
                     }
 
                     try {
-                        Thread.sleep(2000);
+                        Thread.sleep(4000);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
When calling the pollForWifiConnectionStatus(), most of the time Bluetooth GATT failed to read and write the characteristics (Due to multiple read and write). The given workaround works well.

@khushbushah2302 Related to this issue #55 was filed in this repo.

I'm also facing this issue with our devices. Check out this workaround.

