### PR TITLE
feat: WPA3 constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To get this app please clone this repository using the below command:
  ```
 And add a dependency code to your  app module's  `build.gradle`  file. 
 ```  
- implementation 'com.github.espressif:esp-idf-provisioning-android:lib-2.0.13'
+ implementation 'com.github.espressif:esp-idf-provisioning-android:lib-2.0.14'
 ```
 
 ## Using Provisioning Library

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 30
         versionCode 15
-        versionName "2.0.13 - ${getGitHash()}"
+        versionName "2.0.14 - ${getGitHash()}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/provisioning/src/main/java/com/espressif/provisioning/ESPConstants.java
+++ b/provisioning/src/main/java/com/espressif/provisioning/ESPConstants.java
@@ -56,4 +56,6 @@ public class ESPConstants {
     public static final short WIFI_WPA2_PSK = 3;
     public static final short WIFI_WPA_WPA2_PSK = 4;
     public static final short WIFI_WPA2_ENTERPRISE = 5;
+    public static final short WIFI_WPA3_PSK = 6;
+    public static final short WIFI_WPA2_WPA3_PSK = 7;
 }

--- a/provisioning/src/main/proto/wifi_constants.proto
+++ b/provisioning/src/main/proto/wifi_constants.proto
@@ -20,7 +20,10 @@ enum WifiAuthMode {
     WPA2_PSK = 3;
     WPA_WPA2_PSK = 4;
     WPA2_ENTERPRISE = 5;
+    WPA3_PSK = 6;
+    WPA2_WPA3_PSK = 7;
 }
+
 message WifiConnectedState {
     string ip4_addr = 1;
     WifiAuthMode auth_mode = 2;
@@ -28,4 +31,3 @@ message WifiConnectedState {
     bytes bssid = 4;
     int32 channel = 5;
 }
-


### PR DESCRIPTION
The `wifi_constants.proto` file `esp-idf` [contains enum values](https://github.com/espressif/esp-idf/blob/master/components/wifi_provisioning/proto/wifi_constants.proto#L22) describing the WPA2/WPA3 mixed mode and the WPA3 SAE modes. This PR appends the missing enum values to the proto file and to the corresponding Java source.

The lack of theses constants caused issues when scanning for networks when any WPA3 network is available within the range of the ESP device. Connecting to WPA2/WPA3 networks works fine after the fix, with the ESP device selecting the WPA2 mode correctly.