### PR TITLE
fix the gatt client leak

### DIFF
--- a/provisioning/src/main/java/com/espressif/provisioning/transport/BLETransport.java
+++ b/provisioning/src/main/java/com/espressif/provisioning/transport/BLETransport.java
@@ -151,6 +151,7 @@ public class BLETransport implements Transport {
 
         if (this.bluetoothGatt != null) {
             this.bluetoothGatt.disconnect();
+            this.bluetoothGatt.close();
             bluetoothGatt = null;
         }
     }


### PR DESCRIPTION
android register new gatt client internally, when we call the function BluetoothDevice .connect(Boolean autoConnect, BluetoothGattCallback callback, Handler handler). To avoid leak, the client need to be recyled/unregisted by calling close before creating.

https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Bluetooth/framework/java/android/bluetooth/BluetoothGatt.java;drc=cfeac0c69463c7500b6fd86aa3843406f89928d3;l=1085