### PR TITLE
bugfix: harden `ESPDevice` session init against missing/invalid version info

### DIFF
--- a/provisioning/src/main/java/com/espressif/provisioning/ESPDevice.java
+++ b/provisioning/src/main/java/com/espressif/provisioning/ESPDevice.java
@@ -708,6 +708,11 @@ public class ESPDevice {
     }
 
     public void initSession(final ResponseListener listener) {
+        if (listener == null) {
+            Log.e(TAG, "initSession listener is null. Session init aborted.");
+            return;
+        }
+
         ensureVersionInfoForSession(new ResponseListener() {
 
             @Override
@@ -775,7 +780,11 @@ public class ESPDevice {
         } catch (Exception e) {
             e.printStackTrace();
             Log.e(TAG, "Unexpected error while parsing version info.", e);
-            listener.onFailure(new RuntimeException("Failed to parse device version info.", e));
+            if (listener != null) {
+                listener.onFailure(new RuntimeException("Failed to parse device version info.", e));
+            } else {
+                Log.e(TAG, "Failed to notify listener after parsing error because listener is null.");
+            }
             return;
         }
 
@@ -804,17 +813,29 @@ public class ESPDevice {
 
                 @Override
                 public void OnSessionEstablished() {
-                    listener.onSuccess(null);
+                    if (listener != null) {
+                        listener.onSuccess(null);
+                    } else {
+                        Log.e(TAG, "Failed to notify session established because listener is null.");
+                    }
                 }
 
                 @Override
                 public void OnSessionEstablishFailed(Exception e) {
-                    listener.onFailure(e);
+                    if (listener != null) {
+                        listener.onFailure(e);
+                    } else {
+                        Log.e(TAG, "Failed to notify session establish failure because listener is null.", e);
+                    }
                 }
             });
         } catch (Exception e) {
             e.printStackTrace();
-            listener.onFailure(e);
+            if (listener != null) {
+                listener.onFailure(e);
+            } else {
+                Log.e(TAG, "Failed to notify listener after session init exception because listener is null.", e);
+            }
         }
     }
 
@@ -886,17 +907,22 @@ public class ESPDevice {
             Log.e(TAG, "Unexpected error while caching version info.", e);
         }
 
-        deviceCapabilities = parsedCapabilities;
         if (transport instanceof BLETransport) {
             BLETransport bleTransport = (BLETransport) transport;
             bleTransport.versionInfo = data;
             bleTransport.deviceCapabilities.clear();
             bleTransport.deviceCapabilities.addAll(parsedCapabilities);
+            deviceCapabilities = bleTransport.deviceCapabilities;
+        } else {
+            deviceCapabilities = parsedCapabilities;
         }
     }
 
     private void clearCachedVersionInfoAndCapabilities() {
         versionInfo = null;
+        if (deviceCapabilities == null) {
+            deviceCapabilities = new ArrayList<>();
+        }
         deviceCapabilities.clear();
         secPatchVersion = 0;
 

--- a/provisioning/src/main/java/com/espressif/provisioning/ESPDevice.java
+++ b/provisioning/src/main/java/com/espressif/provisioning/ESPDevice.java
@@ -131,6 +131,7 @@ public class ESPDevice {
      */
     @RequiresPermission(allOf = {Manifest.permission.CHANGE_WIFI_STATE, Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.ACCESS_FINE_LOCATION})
     public void connectToDevice() {
+        clearCachedVersionInfoAndCapabilities();
 
         switch (transportType) {
 
@@ -153,6 +154,7 @@ public class ESPDevice {
      */
     @RequiresPermission(Manifest.permission.BLUETOOTH)
     public void connectBLEDevice(BluetoothDevice bluetoothDevice, String primaryServiceUuid) {
+        clearCachedVersionInfoAndCapabilities();
 
         if (transport instanceof BLETransport) {
             deviceName = bluetoothDevice.getName();
@@ -168,6 +170,7 @@ public class ESPDevice {
      */
     @RequiresPermission(Manifest.permission.ACCESS_NETWORK_STATE)
     public void connectWiFiDevice() {
+        clearCachedVersionInfoAndCapabilities();
 
         if (transport instanceof SoftAPTransport) {
 
@@ -189,6 +192,7 @@ public class ESPDevice {
      */
     @RequiresPermission(allOf = {Manifest.permission.CHANGE_WIFI_STATE, Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.ACCESS_FINE_LOCATION})
     public void connectWiFiDevice(String ssid, String password) {
+        clearCachedVersionInfoAndCapabilities();
 
         Log.d(TAG, "connectWiFiDevice ========== SSID : " + ssid + " and Password : " + password);
 
@@ -321,6 +325,7 @@ public class ESPDevice {
             ((BLETransport) transport).disconnect();
         }
         session = null;
+        clearCachedVersionInfoAndCapabilities();
         disableOnlyWifiNetwork();
     }
 
@@ -703,6 +708,23 @@ public class ESPDevice {
     }
 
     public void initSession(final ResponseListener listener) {
+        ensureVersionInfoForSession(new ResponseListener() {
+
+            @Override
+            public void onSuccess(byte[] returnData) {
+                initSessionInternal(listener);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (listener != null) {
+                    listener.onFailure(e);
+                }
+            }
+        });
+    }
+
+    private void initSessionInternal(final ResponseListener listener) {
 
         try {
             JSONObject jsonObject = new JSONObject(getVersionInfo());
@@ -750,6 +772,11 @@ public class ESPDevice {
         } catch (JSONException e) {
             e.printStackTrace();
             Log.d(TAG, "Capabilities JSON not available.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Log.e(TAG, "Unexpected error while parsing version info.", e);
+            listener.onFailure(new RuntimeException("Failed to parse device version info.", e));
+            return;
         }
 
         try {
@@ -788,6 +815,95 @@ public class ESPDevice {
         } catch (Exception e) {
             e.printStackTrace();
             listener.onFailure(e);
+        }
+    }
+
+    private void ensureVersionInfoForSession(final ResponseListener listener) {
+        if (listener == null) {
+            Log.e(TAG, "Cannot ensure version info because listener is null.");
+            return;
+        }
+
+        String existingVersionInfo = getVersionInfo();
+        if (!TextUtils.isEmpty(existingVersionInfo)) {
+            listener.onSuccess(null);
+            return;
+        }
+
+        Log.w(TAG, "Version info unavailable. Fetching capabilities before session init.");
+        transport.sendConfigData(ESPConstants.HANDLER_PROTO_VER, "ESP".getBytes(StandardCharsets.UTF_8), new ResponseListener() {
+
+            @Override
+            public void onSuccess(byte[] returnData) {
+
+                if (returnData == null || returnData.length == 0) {
+                    listener.onFailure(new RuntimeException("Version info response is empty."));
+                    return;
+                }
+
+                String data = new String(returnData, StandardCharsets.UTF_8);
+                if (TextUtils.isEmpty(data)) {
+                    listener.onFailure(new RuntimeException("Version info response is empty."));
+                    return;
+                }
+
+                cacheVersionInfoAndCapabilities(data);
+                listener.onSuccess(returnData);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    private void cacheVersionInfoAndCapabilities(String data) {
+        versionInfo = data;
+        ArrayList<String> parsedCapabilities = new ArrayList<>();
+
+        try {
+            JSONObject jsonObject = new JSONObject(data);
+            JSONObject provInfo = jsonObject.getJSONObject("prov");
+
+            String deviceVersion = provInfo.getString("ver");
+            Log.d(TAG, "Device Version : " + deviceVersion);
+
+            JSONArray capabilities = provInfo.optJSONArray("cap");
+            if (capabilities != null) {
+                for (int i = 0; i < capabilities.length(); i++) {
+                    String cap = capabilities.getString(i);
+                    parsedCapabilities.add(cap);
+                }
+            }
+            Log.d(TAG, "Capabilities : " + parsedCapabilities);
+
+        } catch (JSONException e) {
+            e.printStackTrace();
+            Log.d(TAG, "Capabilities JSON not available.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Log.e(TAG, "Unexpected error while caching version info.", e);
+        }
+
+        deviceCapabilities = parsedCapabilities;
+        if (transport instanceof BLETransport) {
+            BLETransport bleTransport = (BLETransport) transport;
+            bleTransport.versionInfo = data;
+            bleTransport.deviceCapabilities.clear();
+            bleTransport.deviceCapabilities.addAll(parsedCapabilities);
+        }
+    }
+
+    private void clearCachedVersionInfoAndCapabilities() {
+        versionInfo = null;
+        deviceCapabilities.clear();
+        secPatchVersion = 0;
+
+        if (transport instanceof BLETransport) {
+            BLETransport bleTransport = (BLETransport) transport;
+            bleTransport.versionInfo = null;
+            bleTransport.deviceCapabilities.clear();
         }
     }
 
@@ -1652,30 +1768,19 @@ public class ESPDevice {
                 @Override
                 public void onSuccess(byte[] returnData) {
 
+                    if (returnData == null || returnData.length == 0) {
+                        onFailure(new RuntimeException("Version info response is empty."));
+                        return;
+                    }
+
                     String data = new String(returnData, StandardCharsets.UTF_8);
                     Log.d(TAG, "Value : " + data);
-                    versionInfo = data;
-                    deviceCapabilities = new ArrayList<>();
-
-                    try {
-                        JSONObject jsonObject = new JSONObject(data);
-                        JSONObject provInfo = jsonObject.getJSONObject("prov");
-
-                        String versionInfo = provInfo.getString("ver");
-                        Log.d(TAG, "Device Version : " + versionInfo);
-
-                        JSONArray capabilities = provInfo.getJSONArray("cap");
-
-                        for (int i = 0; i < capabilities.length(); i++) {
-                            String cap = capabilities.getString(i);
-                            deviceCapabilities.add(cap);
-                        }
-                        Log.d(TAG, "Capabilities : " + deviceCapabilities);
-
-                    } catch (JSONException e) {
-                        e.printStackTrace();
-                        Log.d(TAG, "Capabilities JSON not available.");
+                    if (TextUtils.isEmpty(data)) {
+                        onFailure(new RuntimeException("Version info response is empty."));
+                        return;
                     }
+
+                    cacheVersionInfoAndCapabilities(data);
                     deviceName = fetchWiFiSSID();
                     handler.removeCallbacks(wifiConnectionFailedTask);
                     EventBus.getDefault().post(new DeviceConnectionEvent(ESPConstants.EVENT_DEVICE_CONNECTED));


### PR DESCRIPTION

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->
Harden `ESPDevice` session init against missing/invalid version info to prevent crashes and improve robustness when interacting with devices that don't respond with version info as expected.`

-   Gate `initSession()` behind `ensureVersionInfoForSession()` so proto version/capabilities are fetched before parsing
-   Split parsing into `initSessionInternal()` and centralise capability parsing/caching in `cacheVersionInfoAndCapabilities()`
-   Add null/empty response guards in `getCapabilitiesTask` to avoid NPE paths
-   Clear cached version/capability/security-patch state on connect/disconnect to prevent stale metadata reuse
-   Add fallback catch (`Exception`) handlers around version-info parsing/caching and fail gracefully via listener callbacks instead of crashing


<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->
Resolves:
https://github.com/espressif/esp-idf-provisioning-android/issues/116

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
Tested within our app to verify that `ESPDevice.provision()` still works as expected.
Crashlytics data will be monitored when the next app release containing this change is published to verify that the original crash is resolved and no new crashes are introduced.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
