### PR TITLE
Guard bluetoothGatt against null at BLETransport write sites

### DIFF
--- a/provisioning/src/main/java/com/espressif/provisioning/transport/BLETransport.java
+++ b/provisioning/src/main/java/com/espressif/provisioning/transport/BLETransport.java
@@ -98,6 +98,15 @@ public class BLETransport implements Transport {
             if (characteristic != null) {
                 try {
                     this.transportToken.acquire();
+                    if (bluetoothGatt == null) {
+                        // The GATT link dropped before this write was dispatched (commonly:
+                        // BLE/Wi-Fi radio contention on the peripheral tore down the
+                        // connection mid-provisioning). Report a clear transport failure
+                        // instead of dereferencing a null bluetoothGatt.
+                        this.transportToken.release();
+                        listener.onFailure(new RuntimeException("BLE transport is disconnected (bluetoothGatt is null); cannot write characteristic."));
+                        return;
+                    }
                     characteristic.setValue(data);
                     bluetoothGatt.writeCharacteristic(characteristic);
                     currentResponseListener = listener;
@@ -278,7 +287,7 @@ public class BLETransport implements Transport {
 
                 BluetoothGattCharacteristic characteristic = service.getCharacteristic(UUID.fromString(uuidMap.get(ESPConstants.HANDLER_PROTO_VER)));
 
-                if (characteristic != null) {
+                if (characteristic != null && bluetoothGatt != null) {
                     // Write anything. It doesn't matter. We need to read characteristic and for that we need to write something.
                     characteristic.setValue("ESP");
                     bluetoothGatt.writeCharacteristic(characteristic);
@@ -421,7 +430,7 @@ public class BLETransport implements Transport {
 
             BluetoothGattCharacteristic characteristic = service.getCharacteristic(UUID.fromString(uuidMap.get(ESPConstants.HANDLER_PROTO_VER)));
 
-            if (characteristic != null) {
+            if (characteristic != null && bluetoothGatt != null) {
                 characteristic.setValue("ESP");
                 bluetoothGatt.writeCharacteristic(characteristic);
             }


### PR DESCRIPTION
## Problem

`sendConfigData()`, `onDescriptorRead()`, and `readNextDescriptor()` in `BLETransport` all call `bluetoothGatt.writeCharacteristic(characteristic)` guarded only by `characteristic != null`. `bluetoothGatt` itself is never checked.

BLE and Wi-Fi usually share one radio on the peripheral, so applying Wi-Fi credentials mid-provisioning can tear down the GATT connection. When that happens, `onConnectionStateChange()` sets `bluetoothGatt` to null on `STATE_DISCONNECTED`. If a write races that teardown, it throws:

```
java.lang.NullPointerException: Attempt to invoke virtual method
'boolean android.bluetooth.BluetoothGatt.writeCharacteristic(android.bluetooth.BluetoothGattCharacteristic)'
on a null object reference
```

`sendConfigData()` at least catches this in its `try/catch` and reports it through `listener.onFailure()`, but as a raw NPE rather than anything that tells the caller what actually happened. `onDescriptorRead()` and `readNextDescriptor()` have no `try/catch` around the write, so the same race throws uncaught on the BLE callback thread.

Seems like this is the root cause behind #51, #63, and #105.

## Fix

Added a `bluetoothGatt != null` check at each of the three sites. `sendConfigData()` now reports a clean failure through the existing `listener.onFailure()` path instead of letting the NPE through. The other two sites fold the check into the existing `characteristic != null` guard, so no structural changes there.

No API changes.

## Testing

I hit this NPE on a real ESP32 device — BLE/Wi-Fi radio contention during a config write — and confirmed the guard stops it. I haven't run this repo's own instrumented test suite yet, so I'm opening as draft until I can get to that or hear a maintainer's take on the approach. Also happy to swap the generic `RuntimeException` for a dedicated exception type if you'd rather have one.
